### PR TITLE
Bump marketplace version to 1.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "from2001-useful-skills",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "A collection of useful agent skills for Claude Code",
   "owner": {
     "name": "Masahiro Yamaguchi"


### PR DESCRIPTION
## Summary
- Increment top-level `version` in `.claude-plugin/marketplace.json` from `1.12.1` → `1.13.0` to reflect the addition of the `x-twitter` skill (merged in #14).
- Per project conventions in CLAUDE.md, the top-level marketplace version must be bumped whenever a new skill is added.

## Test plan
- [ ] Confirm `marketplace.json` parses as valid JSON
- [ ] Confirm version reflects the new skill addition before tagging release v1.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)