### PR TITLE
Add support for animation GIFs and videos

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,8 +63,8 @@
     },
     {
       "name": "x-twitter",
-      "description": "Interact with X (Twitter) API v2 via OAuth 1.0a. 36-command skill to post tweets (with image attachments), search, engage, moderate, and analyze — including threads, communities, trending news, and analytics.",
-      "version": "1.9.0",
+      "description": "Interact with X (Twitter) API v2 via OAuth 1.0a. 36-command skill to post tweets (with image, animated GIF, or video attachments), search, engage, moderate, and analyze — including threads, communities, trending news, and analytics.",
+      "version": "1.10.0",
       "source": "./",
       "skills": ["./.claude/skills/x-twitter"],
       "category": "productivity"

--- a/.claude/skills/x-twitter/README.md
+++ b/.claude/skills/x-twitter/README.md
@@ -13,7 +13,7 @@
 | `search` | Search posts by query (recent or full archive) |
 | `get` | Retrieve post(s) by ID |
 | `thread` | Retrieve a full thread/conversation by any tweet ID |
-| `post` | Create a tweet (optionally with up to 4 images via `--media`, PNG/JPEG/WebP), reply, or quote tweet |
+| `post` | Create a tweet (optionally with up to 4 images, 1 GIF, or 1 video via `--media`), reply, or quote tweet |
 | `delete` | Delete a post |
 
 ### Engagement

--- a/.claude/skills/x-twitter/SKILL.md
+++ b/.claude/skills/x-twitter/SKILL.md
@@ -4,7 +4,7 @@ description: Interact with X (Twitter) API v2. Post tweets, search, engage, mode
 license: MIT
 metadata:
   author: alberduris
-  version: "1.8.0"
+  version: "1.10.0"
   tags: x, twitter, x-twitter, twitter-api, social-media, tweets, automation
 allowed-tools: Bash(node *), Bash(npm *), Bash(npx *), Bash(ls *)
 ---
@@ -19,7 +19,7 @@ Core:
 a) `me` — authenticated user's own account data (profile, metrics, verification). @docs/me.md.
 b) `search` — search posts by query. IMPORTANT: by default searches only the last 7 days; use `--all` (requires X_API_BEARER_TOKEN) for full archive. Do NOT use `search` with `conversation_id:` to read threads — use `thread` instead. @docs/search.md.
 c) `get` — retrieve one or more posts by ID. @docs/get.md.
-d) `post` — create a tweet, reply, or quote tweet. Optionally attach up to 4 images via `--media <paths>` (comma-separated PNG/JPEG/WebP, ≤5 MB each). @docs/post.md.
+d) `post` — create a tweet, reply, or quote tweet. Optionally attach via `--media <paths>` either up to 4 images (PNG/JPEG/WebP, ≤5 MB each) OR 1 animated GIF (≤15 MB) OR 1 video (MP4/MOV/WebM, ≤512 MB). Mixing image with GIF/video is rejected. Video uploads block on transcode polling (up to 10 min). @docs/post.md.
 e) `delete` — delete a post owned by the authenticated user. @docs/delete.md.
 f) `thread` — retrieve a full thread/conversation given any tweet ID. Auto-resolves the conversation, paginates, and returns all tweets sorted chronologically. Use `--all` for threads older than 7 days. @docs/thread.md.
 

--- a/.claude/skills/x-twitter/docs/post.md
+++ b/.claude/skills/x-twitter/docs/post.md
@@ -1,6 +1,6 @@
 Creates a new post (tweet, reply, or quote tweet), optionally with images. Maps to POST /2/tweets (and POST /2/media/upload when `--media` is used). Invoke via `node <base_directory>/x.js post "<text>" [flags]`. Output is JSON to stdout.
 
-[!FLAGS] a) no flags — creates a standalone tweet with the given text. b) `--reply-to <id>` — makes this post a reply to the specified post ID. c) `--quote <id>` — makes this a quote tweet of the specified post ID. d) `--reply-settings <following|mentionedUsers|subscribers|verified>` — restrict who can reply. e) `--media <paths>` — comma-separated list of local image paths to attach. Up to 4 images per tweet, max 5 MB each. Supported formats: PNG, JPEG, WebP. (Animated GIFs and videos require chunked upload and are not supported by this command.) Each file is uploaded first via /2/media/upload (`tweet_image` category), then attached to the tweet by `media_id`.
+[!FLAGS] a) no flags — creates a standalone tweet with the given text. b) `--reply-to <id>` — makes this post a reply to the specified post ID. c) `--quote <id>` — makes this a quote tweet of the specified post ID. d) `--reply-settings <following|mentionedUsers|subscribers|verified>` — restrict who can reply. e) `--media <paths>` — comma-separated list of local media paths. A tweet may include EITHER up to 4 images (PNG/JPEG/WebP, ≤5 MB each) OR exactly 1 animated GIF (≤15 MB) OR exactly 1 video (MP4/MOV/WebM, ≤512 MB). Mixing image with GIF/video is rejected. Images use one-shot `/2/media/upload` (`tweet_image` category). GIF/video use chunked INIT/APPEND/FINALIZE (`tweet_gif` or `tweet_video` category, 4 MB chunks); the command waits on STATUS polling for transcode completion before attaching `media_id` to the tweet (up to 10 minutes).
 
 [!THREADS] To create a thread, post the first tweet, capture its ID from the response, then use `--reply-to <id>` for each subsequent tweet in the chain.
 
@@ -8,6 +8,8 @@ Creates a new post (tweet, reply, or quote tweet), optionally with images. Maps 
 - `node x.js post "Hello world"` — text-only.
 - `node x.js post "Look at this" --media ./photo.png` — single image.
 - `node x.js post "gallery" --media ./a.png,./b.jpg,./c.webp` — multiple images.
+- `node x.js post "look at this gif" --media ./fun.gif` — animated GIF.
+- `node x.js post "demo video" --media ./clip.mp4` — video (waits for transcode).
 - `node x.js post "with reply" --reply-to 1234567890 --media ./img.png` — reply with image.
 
 [!OUTPUT-SHAPE] Returns the API response with `data` containing the created post's `id` and `text`.

--- a/.claude/skills/x-twitter/package.json
+++ b/.claude/skills/x-twitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-twitter-skill",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "36-command Claude Code skill for X/Twitter",
   "license": "MIT",
   "type": "module",

--- a/.claude/skills/x-twitter/src/__tests__/branching.test.ts
+++ b/.claude/skills/x-twitter/src/__tests__/branching.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, beforeEach, mock } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { mockClient } from "./helpers/mock-client.js";
 import { _resetMyIdCache } from "../lib/resolve.js";
 import { user } from "../commands/user.js";
@@ -257,6 +260,56 @@ describe("Pattern E — branching commands", () => {
       assert.deepEqual(body.reply, { inReplyToTweetId: "parent1" });
       assert.equal(body.quoteTweetId, "orig1");
       assert.equal(body.replySettings, "following");
+    });
+
+    it("--media rejects multiple GIFs", async () => {
+      const create = mock.fn(async () => ({ data: { id: "x" } }));
+      const client = mockClient({ posts: { create } });
+      await assert.rejects(
+        () => post(client, ["t", "--media", "a.gif,b.gif"]),
+        /not a mix/,
+      );
+      assert.equal(create.mock.callCount(), 0);
+    });
+
+    it("--media rejects mixing image with video", async () => {
+      const create = mock.fn(async () => ({ data: { id: "x" } }));
+      const client = mockClient({ posts: { create } });
+      await assert.rejects(
+        () => post(client, ["t", "--media", "a.png,b.mp4"]),
+        /not a mix/,
+      );
+      assert.equal(create.mock.callCount(), 0);
+    });
+
+    it("--media accepts a single mp4 via chunked upload", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "x-post-"));
+      try {
+        const file = join(dir, "clip.mp4");
+        writeFileSync(file, Buffer.alloc(2048, 0x09));
+        const initializeUpload = mock.fn(async () => ({
+          data: { id: "vid-9" },
+        }));
+        const appendUpload = mock.fn(async () => ({ data: {} }));
+        const finalizeUpload = mock.fn(async () => ({
+          data: { id: "vid-9" },
+        }));
+        const create = mock.fn(async () => ({
+          data: { id: "tweet-9", text: "v" },
+        }));
+        const client = mockClient({
+          media: { initializeUpload, appendUpload, finalizeUpload },
+          posts: { create },
+        });
+        const result = await post(client, ["v", "--media", file]);
+        assert.deepEqual(result, { data: { id: "tweet-9", text: "v" } });
+        const body = create.mock.calls[0].arguments[0];
+        assert.deepEqual(body.media, { mediaIds: ["vid-9"] });
+        assert.equal(initializeUpload.mock.callCount(), 1);
+        assert.equal(finalizeUpload.mock.callCount(), 1);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/.claude/skills/x-twitter/src/__tests__/media.test.ts
+++ b/.claude/skills/x-twitter/src/__tests__/media.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import {
+  closeSync,
+  ftruncateSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mockClient } from "./helpers/mock-client.js";
+import {
+  classifyMedia,
+  uploadChunked,
+  uploadMedia,
+} from "../lib/media.js";
+
+const noSleep = async (_ms: number) => {};
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "x-media-"));
+}
+
+function writeFixture(dir: string, name: string, contents: Buffer): string {
+  const path = join(dir, name);
+  writeFileSync(path, contents);
+  return path;
+}
+
+function writeSparseFixture(dir: string, name: string, size: number): string {
+  const path = join(dir, name);
+  const fd = openSync(path, "w");
+  try {
+    if (size > 0) {
+      writeSync(fd, Buffer.from([0]), 0, 1, size - 1);
+    }
+    ftruncateSync(fd, size);
+  } finally {
+    closeSync(fd);
+  }
+  return path;
+}
+
+describe("classifyMedia", () => {
+  it("returns 'image' for png/jpg/jpeg/webp", () => {
+    assert.equal(classifyMedia("a.png"), "image");
+    assert.equal(classifyMedia("a.jpg"), "image");
+    assert.equal(classifyMedia("a.JPEG"), "image");
+    assert.equal(classifyMedia("a.webp"), "image");
+  });
+
+  it("returns 'gif' for .gif", () => {
+    assert.equal(classifyMedia("clip.gif"), "gif");
+    assert.equal(classifyMedia("CLIP.GIF"), "gif");
+  });
+
+  it("returns 'video' for mp4/mov/webm", () => {
+    assert.equal(classifyMedia("v.mp4"), "video");
+    assert.equal(classifyMedia("v.MOV"), "video");
+    assert.equal(classifyMedia("v.webm"), "video");
+  });
+
+  it("throws on unknown extension", () => {
+    assert.throws(
+      () => classifyMedia("doc.txt"),
+      /Unsupported media extension/,
+    );
+  });
+});
+
+describe("uploadChunked", () => {
+  it("happy path: GIF, single chunk, no processing", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "fun.gif", Buffer.alloc(1024, 0xab));
+      const initializeUpload = mock.fn(async () => ({
+        data: { id: "media-1" },
+      }));
+      const appendUpload = mock.fn(async () => ({ data: {} }));
+      const finalizeUpload = mock.fn(async () => ({
+        data: { id: "media-1" },
+      }));
+      const getUploadStatus = mock.fn(async () => ({ data: {} }));
+      const client = mockClient({
+        media: {
+          initializeUpload,
+          appendUpload,
+          finalizeUpload,
+          getUploadStatus,
+        },
+      });
+
+      const id = await uploadChunked(client, file, { sleep: noSleep });
+      assert.equal(id, "media-1");
+      assert.equal(initializeUpload.mock.callCount(), 1);
+      const initBody = (
+        initializeUpload.mock.calls[0].arguments[0] as { body: unknown }
+      ).body as { mediaCategory: string; mediaType: string; totalBytes: number };
+      assert.equal(initBody.mediaCategory, "tweet_gif");
+      assert.equal(initBody.mediaType, "image/gif");
+      assert.equal(initBody.totalBytes, 1024);
+      assert.equal(appendUpload.mock.callCount(), 1);
+      const [appendId, appendOpts] = appendUpload.mock.calls[0].arguments as [
+        string,
+        { body: { media: string; segmentIndex: number } },
+      ];
+      assert.equal(appendId, "media-1");
+      assert.equal(appendOpts.body.segmentIndex, 0);
+      assert.equal(
+        appendOpts.body.media,
+        Buffer.alloc(1024, 0xab).toString("base64"),
+      );
+      assert.equal(finalizeUpload.mock.callCount(), 1);
+      assert.equal(finalizeUpload.mock.calls[0].arguments[0], "media-1");
+      assert.equal(getUploadStatus.mock.callCount(), 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("multi-chunk: 200 KB file with 64 KB chunkSize → 4 segments", async () => {
+    const dir = makeTempDir();
+    try {
+      const total = 200 * 1024;
+      const file = writeFixture(dir, "v.mp4", Buffer.alloc(total, 0x01));
+      const initializeUpload = mock.fn(async () => ({
+        data: { id: "v-1" },
+      }));
+      const appendUpload = mock.fn(async () => ({ data: {} }));
+      const finalizeUpload = mock.fn(async () => ({ data: { id: "v-1" } }));
+      const client = mockClient({
+        media: { initializeUpload, appendUpload, finalizeUpload },
+      });
+
+      const id = await uploadChunked(client, file, {
+        sleep: noSleep,
+        chunkSize: 64 * 1024,
+      });
+
+      assert.equal(id, "v-1");
+      assert.equal(appendUpload.mock.callCount(), 4);
+      const segments = appendUpload.mock.calls.map(
+        (c) =>
+          (c.arguments[1] as { body: { segmentIndex: number } }).body
+            .segmentIndex,
+      );
+      assert.deepEqual(segments, [0, 1, 2, 3]);
+      const totalBytes = appendUpload.mock.calls.reduce((sum, c) => {
+        const b = (c.arguments[1] as { body: { media: string } }).body.media;
+        return sum + Buffer.from(b, "base64").length;
+      }, 0);
+      assert.equal(totalBytes, total);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("processing: polls STATUS until succeeded", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "v.mp4", Buffer.alloc(512, 0x02));
+      const initializeUpload = mock.fn(async () => ({
+        data: { id: "v-2" },
+      }));
+      const appendUpload = mock.fn(async () => ({ data: {} }));
+      const finalizeUpload = mock.fn(async () => ({
+        data: {
+          id: "v-2",
+          processingInfo: { state: "pending", checkAfterSecs: 1 },
+        },
+      }));
+      let statusCalls = 0;
+      const getUploadStatus = mock.fn(async () => {
+        statusCalls += 1;
+        if (statusCalls === 1) {
+          return {
+            data: {
+              processingInfo: { state: "in_progress", checkAfterSecs: 1 },
+            },
+          };
+        }
+        return { data: { processingInfo: { state: "succeeded" } } };
+      });
+      const client = mockClient({
+        media: {
+          initializeUpload,
+          appendUpload,
+          finalizeUpload,
+          getUploadStatus,
+        },
+      });
+
+      const id = await uploadChunked(client, file, { sleep: noSleep });
+      assert.equal(id, "v-2");
+      assert.equal(getUploadStatus.mock.callCount(), 2);
+      const [statusId, statusOpts] =
+        getUploadStatus.mock.calls[0].arguments as [
+          string,
+          { command: string },
+        ];
+      assert.equal(statusId, "v-2");
+      assert.equal(statusOpts.command, "STATUS");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("processing: surfaces 'failed' state error message", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "v.mp4", Buffer.alloc(256, 0x03));
+      const initializeUpload = mock.fn(async () => ({
+        data: { id: "v-3" },
+      }));
+      const appendUpload = mock.fn(async () => ({ data: {} }));
+      const finalizeUpload = mock.fn(async () => ({
+        data: {
+          id: "v-3",
+          processingInfo: { state: "pending", checkAfterSecs: 1 },
+        },
+      }));
+      const getUploadStatus = mock.fn(async () => ({
+        data: {
+          processingInfo: {
+            state: "failed",
+            error: { message: "transcode failed" },
+          },
+        },
+      }));
+      const client = mockClient({
+        media: {
+          initializeUpload,
+          appendUpload,
+          finalizeUpload,
+          getUploadStatus,
+        },
+      });
+
+      await assert.rejects(
+        () => uploadChunked(client, file, { sleep: noSleep }),
+        /transcode failed/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("processing: throws on max-wait timeout", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "v.mp4", Buffer.alloc(256, 0x04));
+      const initializeUpload = mock.fn(async () => ({
+        data: { id: "v-4" },
+      }));
+      const appendUpload = mock.fn(async () => ({ data: {} }));
+      const finalizeUpload = mock.fn(async () => ({
+        data: {
+          id: "v-4",
+          processingInfo: { state: "pending", checkAfterSecs: 1 },
+        },
+      }));
+      const getUploadStatus = mock.fn(async () => ({
+        data: { processingInfo: { state: "pending", checkAfterSecs: 1 } },
+      }));
+      const client = mockClient({
+        media: {
+          initializeUpload,
+          appendUpload,
+          finalizeUpload,
+          getUploadStatus,
+        },
+      });
+
+      const slowSleep = (_ms: number) =>
+        new Promise<void>((r) => setTimeout(r, 5));
+      await assert.rejects(
+        () =>
+          uploadChunked(client, file, { sleep: slowSleep, maxWaitMs: 1 }),
+        /timed out/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects 0-byte files before INIT", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "empty.gif", Buffer.alloc(0));
+      const initializeUpload = mock.fn(async () => ({
+        data: { id: "x" },
+      }));
+      const client = mockClient({
+        media: { initializeUpload, appendUpload: async () => ({}) },
+      });
+      await assert.rejects(
+        () => uploadChunked(client, file),
+        /empty/,
+      );
+      assert.equal(initializeUpload.mock.callCount(), 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects GIF over 15 MB cap", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeSparseFixture(dir, "huge.gif", 16 * 1024 * 1024);
+      const initializeUpload = mock.fn(async () => ({
+        data: { id: "x" },
+      }));
+      const client = mockClient({ media: { initializeUpload } });
+      await assert.rejects(
+        () => uploadChunked(client, file),
+        /GIF exceeds 15 MB/,
+      );
+      assert.equal(initializeUpload.mock.callCount(), 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("tags errors with the failing phase", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "x.gif", Buffer.alloc(128, 0x05));
+      const initializeUpload = mock.fn(async () => {
+        throw new Error("boom-init");
+      });
+      const client = mockClient({ media: { initializeUpload } });
+      await assert.rejects(
+        () => uploadChunked(client, file, { sleep: noSleep }),
+        /Media INIT failed: boom-init/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("uploadMedia dispatch", () => {
+  it("routes images to one-shot upload", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "a.png", Buffer.alloc(64, 0x06));
+      const upload = mock.fn(async () => ({ data: { id: "img-1" } }));
+      const initializeUpload = mock.fn(async () => ({ data: { id: "x" } }));
+      const client = mockClient({
+        media: { upload, initializeUpload, appendUpload: async () => ({}) },
+      });
+      const id = await uploadMedia(client, file);
+      assert.equal(id, "img-1");
+      assert.equal(upload.mock.callCount(), 1);
+      assert.equal(initializeUpload.mock.callCount(), 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("routes GIF to chunked upload", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "a.gif", Buffer.alloc(64, 0x07));
+      const upload = mock.fn(async () => ({ data: { id: "ignored" } }));
+      const initializeUpload = mock.fn(async () => ({ data: { id: "g-1" } }));
+      const appendUpload = mock.fn(async () => ({ data: {} }));
+      const finalizeUpload = mock.fn(async () => ({ data: { id: "g-1" } }));
+      const client = mockClient({
+        media: { upload, initializeUpload, appendUpload, finalizeUpload },
+      });
+      const id = await uploadMedia(client, file, { sleep: noSleep });
+      assert.equal(id, "g-1");
+      assert.equal(upload.mock.callCount(), 0);
+      assert.equal(initializeUpload.mock.callCount(), 1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/.claude/skills/x-twitter/src/commands/post.ts
+++ b/.claude/skills/x-twitter/src/commands/post.ts
@@ -1,7 +1,7 @@
 import type { Client } from "@xdevplatform/xdk";
 import { parseArgs } from "../lib/args.js";
 import { resolveEnum } from "../lib/enums.js";
-import { uploadImage } from "../lib/media.js";
+import { classifyMedia, uploadMedia } from "../lib/media.js";
 
 interface PostFlags {
   text: string;
@@ -42,14 +42,22 @@ export async function post(
   }
 
   if (flags.mediaPaths && flags.mediaPaths.length > 0) {
-    if (flags.mediaPaths.length > 4) {
+    const kinds = flags.mediaPaths.map((p) => classifyMedia(p));
+    const hasGifOrVideo = kinds.some((k) => k === "gif" || k === "video");
+    const hasImage = kinds.some((k) => k === "image");
+    if (hasGifOrVideo && (hasImage || flags.mediaPaths.length > 1)) {
+      throw new Error(
+        "--media: a tweet may include up to 4 images, OR exactly 1 animated GIF, OR exactly 1 video — not a mix",
+      );
+    }
+    if (hasImage && flags.mediaPaths.length > 4) {
       throw new Error(
         `--media accepts at most 4 image paths (got ${flags.mediaPaths.length})`,
       );
     }
     const mediaIds: string[] = [];
     for (const path of flags.mediaPaths) {
-      mediaIds.push(await uploadImage(client, path));
+      mediaIds.push(await uploadMedia(client, path));
     }
     body.media = { mediaIds };
   }


### PR DESCRIPTION
This pull request adds support for posting tweets with animated GIF and video attachments (in addition to images) in the X (Twitter) skill, updating documentation, validation, and tests accordingly. It introduces chunked upload logic for GIFs and videos, enforces new media constraints, and increases the skill version to 1.10.0.

**Media Attachment Enhancements:**

* The `post` command now supports attaching either up to 4 images, 1 animated GIF, or 1 video (MP4/MOV/WebM), with strict enforcement against mixing types and new size limits for GIFs (≤15 MB) and videos (≤512 MB). Video uploads include transcode polling (up to 10 minutes). (`.claude/skills/x-twitter/src/commands/post.ts`, `.claude/skills/x-twitter/docs/post.md`, `.claude/skills/x-twitter/SKILL.md`, `.claude/skills/x-twitter/README.md`) [[1]](diffhunk://#diff-1af68574d61c4ff9a158486061316d8a1f5e2f5a6e301386ebd256a211905447L45-R60) [[2]](diffhunk://#diff-309347f7a849ff2e9d62a31af0f8c0dac13d3444b83aa4605147a55211c21cf9L3-R12) [[3]](diffhunk://#diff-c38a6c1d323d5f63b64ab4313e90548d9e547642de2e6131f845e9027335afddL22-R22) [[4]](diffhunk://#diff-9369035a2881599af1dd7f124b22c7615416da9e3ab8d44393e6cdfcb62b0a79L16-R16)
* Added new logic to classify media types and dispatch uploads accordingly, including chunked upload and polling for GIFs/videos. (`.claude/skills/x-twitter/src/commands/post.ts`, `.claude/skills/x-twitter/src/lib/media.js`)

**Testing Improvements:**

* Added comprehensive tests for media classification, chunked upload (including error handling, timeouts, and size checks), and post command validation for media constraints. (`.claude/skills/x-twitter/src/__tests__/media.test.ts`, `.claude/skills/x-twitter/src/__tests__/branching.test.ts`) [[1]](diffhunk://#diff-d5fac4d55dee26671bba5af9fcb55367b5cdcd7012db2d35622b6da7a7104f39R1-R383) [[2]](diffhunk://#diff-ebb2e3e2f6a3a4d14bd1d679db6d204897b69608311fde0eeab9ccee216ac4a5R264-R313)

**Documentation and Metadata Updates:**

* Updated documentation to reflect the new media capabilities, constraints, and usage examples. (`.claude/skills/x-twitter/docs/post.md`, `.claude/skills/x-twitter/README.md`, `.claude/skills/x-twitter/SKILL.md`) [[1]](diffhunk://#diff-309347f7a849ff2e9d62a31af0f8c0dac13d3444b83aa4605147a55211c21cf9L3-R12) [[2]](diffhunk://#diff-9369035a2881599af1dd7f124b22c7615416da9e3ab8d44393e6cdfcb62b0a79L16-R16) [[3]](diffhunk://#diff-c38a6c1d323d5f63b64ab4313e90548d9e547642de2e6131f845e9027335afddL22-R22)
* Bumped version numbers and updated descriptions to indicate support for GIF/video media. (`.claude/skills/x-twitter/package.json`, `.claude/skills/x-twitter/SKILL.md`, `.claude-plugin/marketplace.json`) [[1]](diffhunk://#diff-f2820d779429be4fb30adc490f3406c135416a921253a4f7ed3f85be80124bb7L3-R3) [[2]](diffhunk://#diff-c38a6c1d323d5f63b64ab4313e90548d9e547642de2e6131f845e9027335afddL7-R7) [[3]](diffhunk://#diff-5352ee4067f17e7948e1425843f0a454e045bc8edf338f0bcf75c6804ddabd9aL66-R67)