### PR TITLE
chore: bump marketplace version to 1.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "from2001-useful-skills",
-  "version": "1.12.1",
+  "version": "1.14.0",
   "description": "A collection of useful agent skills for Claude Code",
   "owner": {
     "name": "Masahiro Yamaguchi"


### PR DESCRIPTION
## Summary
- Bump top-level `marketplace.json` version `1.12.1` → `1.14.0`
- Aligns the field with the actual release tags (v1.13.0 / upcoming v1.14.0); it had drifted out of sync since the last bump

## Why
The release notes for v1.13.0 already advertised version `1.13.0`, but the file itself was never updated. The upcoming v1.14.0 draft (x-twitter GIF/video support) bumps it forward to the correct value in one go.

## Test plan
- [ ] Confirm `.claude-plugin/marketplace.json` parses (no syntax error)
- [ ] Verify per-plugin versions are unchanged