### PR TITLE
fix(x-twitter): bypass broken SDK appendUpload with direct multipart fetch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "from2001-useful-skills",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "A collection of useful agent skills for Claude Code",
   "owner": {
     "name": "Masahiro Yamaguchi"
@@ -64,7 +64,7 @@
     {
       "name": "x-twitter",
       "description": "Interact with X (Twitter) API v2 via OAuth 1.0a. 36-command skill to post tweets (with image, animated GIF, or video attachments), search, engage, moderate, and analyze — including threads, communities, trending news, and analytics.",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "source": "./",
       "skills": ["./.claude/skills/x-twitter"],
       "category": "productivity"

--- a/.claude/skills/x-twitter/package.json
+++ b/.claude/skills/x-twitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-twitter-skill",
-  "version": "1.10.0",
+  "version": "1.10.2",
   "description": "36-command Claude Code skill for X/Twitter",
   "license": "MIT",
   "type": "module",

--- a/.claude/skills/x-twitter/src/__tests__/branching.test.ts
+++ b/.claude/skills/x-twitter/src/__tests__/branching.test.ts
@@ -284,13 +284,13 @@ describe("Pattern E — branching commands", () => {
 
     it("--media accepts a single mp4 via chunked upload", async () => {
       const dir = mkdtempSync(join(tmpdir(), "x-post-"));
+      const originalFetch = globalThis.fetch;
       try {
         const file = join(dir, "clip.mp4");
         writeFileSync(file, Buffer.alloc(2048, 0x09));
         const initializeUpload = mock.fn(async () => ({
           data: { id: "vid-9" },
         }));
-        const appendUpload = mock.fn(async () => ({ data: {} }));
         const finalizeUpload = mock.fn(async () => ({
           data: { id: "vid-9" },
         }));
@@ -298,9 +298,20 @@ describe("Pattern E — branching commands", () => {
           data: { id: "tweet-9", text: "v" },
         }));
         const client = mockClient({
-          media: { initializeUpload, appendUpload, finalizeUpload },
+          media: { initializeUpload, finalizeUpload },
           posts: { create },
+          oauth1: {
+            buildRequestHeader: async () => "OAuth oauth_consumer_key=\"k\"",
+          },
+          baseUrl: "https://api.x.com",
         });
+        // Stub global fetch so the multipart APPEND request doesn't hit the network.
+        globalThis.fetch = (async () => ({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => "",
+        })) as unknown as typeof fetch;
         const result = await post(client, ["v", "--media", file]);
         assert.deepEqual(result, { data: { id: "tweet-9", text: "v" } });
         const body = create.mock.calls[0].arguments[0];
@@ -308,6 +319,7 @@ describe("Pattern E — branching commands", () => {
         assert.equal(initializeUpload.mock.callCount(), 1);
         assert.equal(finalizeUpload.mock.callCount(), 1);
       } finally {
+        globalThis.fetch = originalFetch;
         rmSync(dir, { recursive: true, force: true });
       }
     });

--- a/.claude/skills/x-twitter/src/__tests__/media.test.ts
+++ b/.claude/skills/x-twitter/src/__tests__/media.test.ts
@@ -20,6 +20,85 @@ import {
 
 const noSleep = async (_ms: number) => {};
 
+interface FetchCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+function makeFakeFetch(opts: {
+  status?: number;
+  statusText?: string;
+  responseBody?: string;
+  calls?: FetchCall[];
+} = {}) {
+  const status = opts.status ?? 200;
+  const statusText = opts.statusText ?? "OK";
+  const responseBody = opts.responseBody ?? "";
+  const calls = opts.calls ?? [];
+  return async (url: string | URL, init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: Buffer | Uint8Array | string;
+  }) => {
+    const bodyBuf =
+      init?.body instanceof Buffer
+        ? init.body
+        : init?.body instanceof Uint8Array
+          ? Buffer.from(init.body)
+          : Buffer.from(typeof init?.body === "string" ? init.body : "");
+    calls.push({
+      url: String(url),
+      method: init?.method ?? "GET",
+      headers: init?.headers ?? {},
+      body: bodyBuf,
+    });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText,
+      text: async () => responseBody,
+    };
+  };
+}
+
+function clientWithOAuth1(media: Record<string, unknown>): ReturnType<typeof mockClient> {
+  return mockClient({
+    media,
+    oauth1: {
+      buildRequestHeader: async () => "OAuth oauth_consumer_key=\"k\"",
+    },
+    baseUrl: "https://api.x.com",
+  });
+}
+
+function parseMultipartFields(body: Buffer, boundary: string): {
+  segmentIndex?: string;
+  mediaBytes?: Buffer;
+} {
+  const sep = `--${boundary}`;
+  const text = body.toString("binary");
+  const parts = text.split(sep).filter((p) => p && p !== "--\r\n" && p !== "--");
+  const out: { segmentIndex?: string; mediaBytes?: Buffer } = {};
+  for (const partRaw of parts) {
+    const part = partRaw.startsWith("\r\n") ? partRaw.slice(2) : partRaw;
+    const trimmed = part.endsWith("\r\n") ? part.slice(0, -2) : part;
+    const headerEnd = trimmed.indexOf("\r\n\r\n");
+    if (headerEnd < 0) continue;
+    const headerBlock = trimmed.slice(0, headerEnd);
+    const value = trimmed.slice(headerEnd + 4);
+    const nameMatch = /name="([^"]+)"/.exec(headerBlock);
+    if (!nameMatch) continue;
+    if (nameMatch[1] === "segment_index") {
+      out.segmentIndex = value;
+    } else if (nameMatch[1] === "media") {
+      out.mediaBytes = Buffer.from(value, "binary");
+    }
+  }
+  return out;
+}
+
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), "x-media-"));
 }
@@ -79,21 +158,21 @@ describe("uploadChunked", () => {
       const initializeUpload = mock.fn(async () => ({
         data: { id: "media-1" },
       }));
-      const appendUpload = mock.fn(async () => ({ data: {} }));
       const finalizeUpload = mock.fn(async () => ({
         data: { id: "media-1" },
       }));
       const getUploadStatus = mock.fn(async () => ({ data: {} }));
-      const client = mockClient({
-        media: {
-          initializeUpload,
-          appendUpload,
-          finalizeUpload,
-          getUploadStatus,
-        },
+      const client = clientWithOAuth1({
+        initializeUpload,
+        finalizeUpload,
+        getUploadStatus,
       });
 
-      const id = await uploadChunked(client, file, { sleep: noSleep });
+      const fetchCalls: FetchCall[] = [];
+      const id = await uploadChunked(client, file, {
+        sleep: noSleep,
+        fetchImpl: makeFakeFetch({ calls: fetchCalls }),
+      });
       assert.equal(id, "media-1");
       assert.equal(initializeUpload.mock.callCount(), 1);
       const initBody = (
@@ -102,17 +181,21 @@ describe("uploadChunked", () => {
       assert.equal(initBody.mediaCategory, "tweet_gif");
       assert.equal(initBody.mediaType, "image/gif");
       assert.equal(initBody.totalBytes, 1024);
-      assert.equal(appendUpload.mock.callCount(), 1);
-      const [appendId, appendOpts] = appendUpload.mock.calls[0].arguments as [
-        string,
-        { body: { media: string; segmentIndex: number } },
-      ];
-      assert.equal(appendId, "media-1");
-      assert.equal(appendOpts.body.segmentIndex, 0);
+      assert.equal(fetchCalls.length, 1);
+      const call = fetchCalls[0];
+      assert.equal(call.method, "POST");
       assert.equal(
-        appendOpts.body.media,
-        Buffer.alloc(1024, 0xab).toString("base64"),
+        call.url,
+        "https://api.x.com/2/media/upload/media-1/append",
       );
+      assert.match(call.headers.Authorization, /^OAuth /);
+      const ctMatch = /multipart\/form-data; boundary=(.+)$/.exec(
+        call.headers["Content-Type"],
+      );
+      assert.ok(ctMatch, "Content-Type must be multipart/form-data");
+      const fields = parseMultipartFields(call.body, ctMatch![1]);
+      assert.equal(fields.segmentIndex, "0");
+      assert.deepEqual(fields.mediaBytes, Buffer.alloc(1024, 0xab));
       assert.equal(finalizeUpload.mock.callCount(), 1);
       assert.equal(finalizeUpload.mock.calls[0].arguments[0], "media-1");
       assert.equal(getUploadStatus.mock.callCount(), 0);
@@ -129,29 +212,28 @@ describe("uploadChunked", () => {
       const initializeUpload = mock.fn(async () => ({
         data: { id: "v-1" },
       }));
-      const appendUpload = mock.fn(async () => ({ data: {} }));
       const finalizeUpload = mock.fn(async () => ({ data: { id: "v-1" } }));
-      const client = mockClient({
-        media: { initializeUpload, appendUpload, finalizeUpload },
-      });
+      const client = clientWithOAuth1({ initializeUpload, finalizeUpload });
 
+      const fetchCalls: FetchCall[] = [];
       const id = await uploadChunked(client, file, {
         sleep: noSleep,
         chunkSize: 64 * 1024,
+        fetchImpl: makeFakeFetch({ calls: fetchCalls }),
       });
 
       assert.equal(id, "v-1");
-      assert.equal(appendUpload.mock.callCount(), 4);
-      const segments = appendUpload.mock.calls.map(
-        (c) =>
-          (c.arguments[1] as { body: { segmentIndex: number } }).body
-            .segmentIndex,
-      );
-      assert.deepEqual(segments, [0, 1, 2, 3]);
-      const totalBytes = appendUpload.mock.calls.reduce((sum, c) => {
-        const b = (c.arguments[1] as { body: { media: string } }).body.media;
-        return sum + Buffer.from(b, "base64").length;
-      }, 0);
+      assert.equal(fetchCalls.length, 4);
+      const segments: string[] = [];
+      let totalBytes = 0;
+      for (const call of fetchCalls) {
+        const ctMatch = /boundary=(.+)$/.exec(call.headers["Content-Type"]);
+        assert.ok(ctMatch);
+        const fields = parseMultipartFields(call.body, ctMatch![1]);
+        segments.push(fields.segmentIndex ?? "");
+        totalBytes += fields.mediaBytes?.length ?? 0;
+      }
+      assert.deepEqual(segments, ["0", "1", "2", "3"]);
       assert.equal(totalBytes, total);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -165,7 +247,6 @@ describe("uploadChunked", () => {
       const initializeUpload = mock.fn(async () => ({
         data: { id: "v-2" },
       }));
-      const appendUpload = mock.fn(async () => ({ data: {} }));
       const finalizeUpload = mock.fn(async () => ({
         data: {
           id: "v-2",
@@ -184,16 +265,16 @@ describe("uploadChunked", () => {
         }
         return { data: { processingInfo: { state: "succeeded" } } };
       });
-      const client = mockClient({
-        media: {
-          initializeUpload,
-          appendUpload,
-          finalizeUpload,
-          getUploadStatus,
-        },
+      const client = clientWithOAuth1({
+        initializeUpload,
+        finalizeUpload,
+        getUploadStatus,
       });
 
-      const id = await uploadChunked(client, file, { sleep: noSleep });
+      const id = await uploadChunked(client, file, {
+        sleep: noSleep,
+        fetchImpl: makeFakeFetch(),
+      });
       assert.equal(id, "v-2");
       assert.equal(getUploadStatus.mock.callCount(), 2);
       const [statusId, statusOpts] =
@@ -215,7 +296,6 @@ describe("uploadChunked", () => {
       const initializeUpload = mock.fn(async () => ({
         data: { id: "v-3" },
       }));
-      const appendUpload = mock.fn(async () => ({ data: {} }));
       const finalizeUpload = mock.fn(async () => ({
         data: {
           id: "v-3",
@@ -230,17 +310,18 @@ describe("uploadChunked", () => {
           },
         },
       }));
-      const client = mockClient({
-        media: {
-          initializeUpload,
-          appendUpload,
-          finalizeUpload,
-          getUploadStatus,
-        },
+      const client = clientWithOAuth1({
+        initializeUpload,
+        finalizeUpload,
+        getUploadStatus,
       });
 
       await assert.rejects(
-        () => uploadChunked(client, file, { sleep: noSleep }),
+        () =>
+          uploadChunked(client, file, {
+            sleep: noSleep,
+            fetchImpl: makeFakeFetch(),
+          }),
         /transcode failed/,
       );
     } finally {
@@ -255,7 +336,6 @@ describe("uploadChunked", () => {
       const initializeUpload = mock.fn(async () => ({
         data: { id: "v-4" },
       }));
-      const appendUpload = mock.fn(async () => ({ data: {} }));
       const finalizeUpload = mock.fn(async () => ({
         data: {
           id: "v-4",
@@ -265,20 +345,21 @@ describe("uploadChunked", () => {
       const getUploadStatus = mock.fn(async () => ({
         data: { processingInfo: { state: "pending", checkAfterSecs: 1 } },
       }));
-      const client = mockClient({
-        media: {
-          initializeUpload,
-          appendUpload,
-          finalizeUpload,
-          getUploadStatus,
-        },
+      const client = clientWithOAuth1({
+        initializeUpload,
+        finalizeUpload,
+        getUploadStatus,
       });
 
       const slowSleep = (_ms: number) =>
         new Promise<void>((r) => setTimeout(r, 5));
       await assert.rejects(
         () =>
-          uploadChunked(client, file, { sleep: slowSleep, maxWaitMs: 1 }),
+          uploadChunked(client, file, {
+            sleep: slowSleep,
+            maxWaitMs: 1,
+            fetchImpl: makeFakeFetch(),
+          }),
         /timed out/,
       );
     } finally {
@@ -293,11 +374,9 @@ describe("uploadChunked", () => {
       const initializeUpload = mock.fn(async () => ({
         data: { id: "x" },
       }));
-      const client = mockClient({
-        media: { initializeUpload, appendUpload: async () => ({}) },
-      });
+      const client = clientWithOAuth1({ initializeUpload });
       await assert.rejects(
-        () => uploadChunked(client, file),
+        () => uploadChunked(client, file, { fetchImpl: makeFakeFetch() }),
         /empty/,
       );
       assert.equal(initializeUpload.mock.callCount(), 0);
@@ -313,9 +392,9 @@ describe("uploadChunked", () => {
       const initializeUpload = mock.fn(async () => ({
         data: { id: "x" },
       }));
-      const client = mockClient({ media: { initializeUpload } });
+      const client = clientWithOAuth1({ initializeUpload });
       await assert.rejects(
-        () => uploadChunked(client, file),
+        () => uploadChunked(client, file, { fetchImpl: makeFakeFetch() }),
         /GIF exceeds 15 MB/,
       );
       assert.equal(initializeUpload.mock.callCount(), 0);
@@ -331,10 +410,43 @@ describe("uploadChunked", () => {
       const initializeUpload = mock.fn(async () => {
         throw new Error("boom-init");
       });
-      const client = mockClient({ media: { initializeUpload } });
+      const client = clientWithOAuth1({ initializeUpload });
       await assert.rejects(
-        () => uploadChunked(client, file, { sleep: noSleep }),
+        () =>
+          uploadChunked(client, file, {
+            sleep: noSleep,
+            fetchImpl: makeFakeFetch(),
+          }),
         /Media INIT failed: boom-init/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces APPEND HTTP errors with status, statusText, and body excerpt", async () => {
+    const dir = makeTempDir();
+    try {
+      const file = writeFixture(dir, "fun.gif", Buffer.alloc(64, 0xab));
+      const initializeUpload = mock.fn(async () => ({
+        data: { id: "media-err" },
+      }));
+      const finalizeUpload = mock.fn(async () => ({ data: { id: "media-err" } }));
+      const client = clientWithOAuth1({ initializeUpload, finalizeUpload });
+
+      await assert.rejects(
+        () =>
+          uploadChunked(client, file, {
+            sleep: noSleep,
+            fetchImpl: makeFakeFetch({
+              status: 400,
+              statusText: "Bad Request",
+              responseBody: JSON.stringify({
+                errors: [{ message: "Invalid segment_index" }],
+              }),
+            }),
+          }),
+        /Media APPEND failed at segment 0: HTTP 400 Bad Request: Invalid segment_index/,
       );
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -349,9 +461,7 @@ describe("uploadMedia dispatch", () => {
       const file = writeFixture(dir, "a.png", Buffer.alloc(64, 0x06));
       const upload = mock.fn(async () => ({ data: { id: "img-1" } }));
       const initializeUpload = mock.fn(async () => ({ data: { id: "x" } }));
-      const client = mockClient({
-        media: { upload, initializeUpload, appendUpload: async () => ({}) },
-      });
+      const client = clientWithOAuth1({ upload, initializeUpload });
       const id = await uploadMedia(client, file);
       assert.equal(id, "img-1");
       assert.equal(upload.mock.callCount(), 1);
@@ -367,12 +477,12 @@ describe("uploadMedia dispatch", () => {
       const file = writeFixture(dir, "a.gif", Buffer.alloc(64, 0x07));
       const upload = mock.fn(async () => ({ data: { id: "ignored" } }));
       const initializeUpload = mock.fn(async () => ({ data: { id: "g-1" } }));
-      const appendUpload = mock.fn(async () => ({ data: {} }));
       const finalizeUpload = mock.fn(async () => ({ data: { id: "g-1" } }));
-      const client = mockClient({
-        media: { upload, initializeUpload, appendUpload, finalizeUpload },
+      const client = clientWithOAuth1({ upload, initializeUpload, finalizeUpload });
+      const id = await uploadMedia(client, file, {
+        sleep: noSleep,
+        fetchImpl: makeFakeFetch(),
       });
-      const id = await uploadMedia(client, file, { sleep: noSleep });
       assert.equal(id, "g-1");
       assert.equal(upload.mock.callCount(), 0);
       assert.equal(initializeUpload.mock.callCount(), 1);

--- a/.claude/skills/x-twitter/src/lib/media.ts
+++ b/.claude/skills/x-twitter/src/lib/media.ts
@@ -1,6 +1,21 @@
 import { closeSync, openSync, readFileSync, readSync, statSync } from "fs";
+import { randomBytes } from "crypto";
 import { extname, resolve } from "path";
 import type { Client } from "@xdevplatform/xdk";
+
+type FetchLike = (
+  input: string | URL,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: Buffer | Uint8Array | string;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  text(): Promise<string>;
+}>;
 
 const MAX_BYTES = 5 * 1024 * 1024;
 const CHUNK_SIZE = 4 * 1024 * 1024;
@@ -102,6 +117,74 @@ export interface UploadChunkedOptions {
   sleep?: (ms: number) => Promise<void>;
   maxWaitMs?: number;
   chunkSize?: number;
+  fetchImpl?: FetchLike;
+}
+
+// X v2 chunked APPEND endpoint expects multipart/form-data, but
+// @xdevplatform/xdk@0.4.0 sends JSON and then double-reads the error body
+// ("Body is unusable"). We bypass the SDK and POST multipart/form-data
+// directly with an OAuth1-signed Authorization header. Multipart bodies
+// are not part of the OAuth1 signature base string, so the body argument
+// passed to buildRequestHeader is the empty string.
+async function appendChunkMultipart(
+  client: Client,
+  mediaId: string,
+  chunk: Buffer,
+  segmentIndex: number,
+  fetchImpl: FetchLike,
+): Promise<void> {
+  const oauth1 = (client as unknown as { oauth1?: { buildRequestHeader: (m: string, u: string, b: string) => Promise<string> } }).oauth1;
+  if (!oauth1) {
+    throw new Error("OAuth1 credentials are required for chunked media upload");
+  }
+  const baseUrl = (client as unknown as { baseUrl?: string }).baseUrl ?? "https://api.x.com";
+  const url = `${baseUrl}/2/media/upload/${encodeURIComponent(mediaId)}/append`;
+  const authHeader = await oauth1.buildRequestHeader("POST", url, "");
+
+  const boundary = `----xskill${randomBytes(16).toString("hex")}`;
+  const CRLF = "\r\n";
+  const head = Buffer.from(
+    `--${boundary}${CRLF}` +
+      `Content-Disposition: form-data; name="segment_index"${CRLF}${CRLF}` +
+      `${segmentIndex}${CRLF}` +
+      `--${boundary}${CRLF}` +
+      `Content-Disposition: form-data; name="media"; filename="blob"${CRLF}` +
+      `Content-Type: application/octet-stream${CRLF}${CRLF}`,
+    "utf8",
+  );
+  const tail = Buffer.from(`${CRLF}--${boundary}--${CRLF}`, "utf8");
+  const body = Buffer.concat([head, chunk, tail]);
+
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      Authorization: authHeader,
+      "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      "Content-Length": String(body.length),
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    let detail = text;
+    try {
+      const parsed = JSON.parse(text) as {
+        message?: string;
+        errors?: { message?: string }[];
+      };
+      detail =
+        parsed.message ??
+        parsed.errors?.[0]?.message ??
+        text;
+    } catch {
+      // not JSON; use raw text
+    }
+    const trimmed = detail.length > 300 ? `${detail.slice(0, 300)}…` : detail;
+    throw new Error(
+      `HTTP ${response.status} ${response.statusText}${trimmed ? `: ${trimmed}` : ""}`,
+    );
+  }
 }
 
 interface ProcessingInfo {
@@ -212,6 +295,7 @@ export async function uploadChunked(
   }
 
   const chunkSize = opts.chunkSize ?? CHUNK_SIZE;
+  const fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
   const buffer = Buffer.alloc(chunkSize);
   const fd = openSync(absolute, "r");
   try {
@@ -220,11 +304,15 @@ export async function uploadChunked(
     while (offset < stats.size) {
       const bytesRead = readSync(fd, buffer, 0, chunkSize, offset);
       if (bytesRead <= 0) break;
-      const base64Chunk = buffer.subarray(0, bytesRead).toString("base64");
+      const chunk = Buffer.from(buffer.subarray(0, bytesRead));
       try {
-        await client.media.appendUpload(mediaId, {
-          body: { media: base64Chunk, segmentIndex },
-        });
+        await appendChunkMultipart(
+          client,
+          mediaId,
+          chunk,
+          segmentIndex,
+          fetchImpl,
+        );
       } catch (err) {
         throw new Error(
           `Media APPEND failed at segment ${segmentIndex}: ${(err as Error).message}`,


### PR DESCRIPTION
## Summary
- `@xdevplatform/xdk@0.4.0` の `appendUpload` は chunked media の APPEND ボディを **JSON で送信** し、さらにエラー時にレスポンスボディを **2 回読んでしまう**ため、`Body is unusable: Body has already been read` で本当のエラーが完全に隠蔽されていました（GIF/動画添付投稿で再現）。
- SDK 経由をやめ、`/2/media/upload/{id}/append` を **OAuth1 署名付きの `multipart/form-data`** で直接 POST する `appendChunkMultipart()` を `src/lib/media.ts` に新設し、`uploadChunked()` から呼ぶよう差し替え。
- 失敗時はレスポンスボディを **一度だけ** `text()` で読み、JSON 解釈を試みた上で `HTTP <status> <statusText>: <message>` を投げるので、X API が返す本当のエラー文言がそのまま伝播します。
- `x-twitter` を `1.10.1 → 1.10.2`、marketplace top-level を `1.14.1 → 1.14.2` に bump。

## Test plan
- [x] `npm test` — 112/112 通過（multipart ボディ・segment_index・OAuth ヘッダ・HTTP 4xx メッセージ伝播の新規アサーションを含む）
- [x] `npm run build` — エラーなし
- [ ] 実機 GIF 投稿で APPEND が 200 を返すことを確認
- [ ] 実機 mp4 投稿（chunked） で同じく成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)