### PR TITLE
docs(csharp-roslyn-lsp): document macOS/Linux PATH workaround (v1.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "from2001-useful-skills",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "description": "A collection of useful agent skills for Claude Code",
   "owner": {
     "name": "Masahiro Yamaguchi"
@@ -57,7 +57,7 @@
     {
       "name": "csharp-roslyn-lsp",
       "description": "Microsoft Roslyn-based C# language server for Claude Code. Drop-in replacement for csharp-lsp@claude-plugins-official for projects whose .csproj files Roslyn handles but csharp-ls rejects (Unity, generated SDK-style csproj with explicit Sdk.props imports, etc.).",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "source": "./plugins/csharp-roslyn-lsp",
       "category": "developer-tools"
     },

--- a/plugins/csharp-roslyn-lsp/.claude-plugin/plugin.json
+++ b/plugins/csharp-roslyn-lsp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "csharp-roslyn-lsp",
   "description": "Microsoft Roslyn-based C# language server for Claude Code. Drop-in alternative to csharp-lsp@claude-plugins-official for projects whose .csproj files Roslyn handles but csharp-ls rejects (Unity, generated SDK-style csproj with explicit Sdk.props imports, etc.).",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "author": {
     "name": "Masahiro Yamaguchi"
   },

--- a/plugins/csharp-roslyn-lsp/README.md
+++ b/plugins/csharp-roslyn-lsp/README.md
@@ -36,6 +36,26 @@ If the official `csharp-lsp` plugin is also enabled, disable it for this project
 
 Then `/reload-plugins`.
 
+### macOS / Linux: one-time PATH setup
+
+Claude Code does not currently add a plugin's `bin/` directory to the LSP child process's `PATH` on macOS or Linux either. Even though `which csharp-roslyn-lsp` succeeds in your interactive shell after install, the LSP-tool subprocess uses a more minimal `$PATH` that does not include the plugin cache, so Claude Code returns:
+
+```
+Error performing documentSymbol: Executable not found in $PATH: "csharp-roslyn-lsp"
+```
+
+Work around it by symlinking the launcher into `~/.local/bin`, which the LSP child process does see (no `sudo` required). Run in a shell:
+
+```bash
+plugin_dir="$HOME/.claude/plugins/cache/from2001-useful-skills/csharp-roslyn-lsp"
+latest="$(ls -1 "$plugin_dir" 2>/dev/null | sort -V | tail -n 1)"
+mkdir -p "$HOME/.local/bin"
+ln -sf "$plugin_dir/$latest/bin/csharp-roslyn-lsp" "$HOME/.local/bin/csharp-roslyn-lsp"
+echo "Linked: $HOME/.local/bin/csharp-roslyn-lsp -> $plugin_dir/$latest/bin/csharp-roslyn-lsp"
+```
+
+Restart Claude Code afterwards so the new `PATH` is picked up. Note that the cache path includes the installed plugin version (e.g. `1.1.0/bin`); when the plugin auto-updates to a new version the symlink will go stale — re-run the snippet to repoint it.
+
 ### Windows: one-time PATH setup
 
 Claude Code does not currently add a plugin's `bin/` directory to the LSP child process's `PATH` on Windows. Until that ships upstream, `child_process.spawn('csharp-roslyn-lsp')` cannot locate `csharp-roslyn-lsp.cmd` and Claude Code returns:
@@ -59,7 +79,7 @@ if (-not (($user -split ';') -contains $bin)) {
 }
 ```
 
-Restart Claude Code afterwards so the new `PATH` is picked up. Note that the cache path includes the installed plugin version (e.g. `1.0.0\bin`); when the plugin auto-updates to a new version the entry will go stale — re-run the snippet to repoint it.
+Restart Claude Code afterwards so the new `PATH` is picked up. Note that the cache path includes the installed plugin version (e.g. `1.1.0\bin`); when the plugin auto-updates to a new version the entry will go stale — re-run the snippet to repoint it.
 
 ## Verifying
 
@@ -72,6 +92,7 @@ The running process appears as a `dotnet` child hosting `Microsoft.CodeAnalysis.
 
 ## Troubleshooting
 
+- **`Executable not found in $PATH: "csharp-roslyn-lsp"` on macOS / Linux** — the plugin's `bin/` directory is not on the Claude Code LSP child-process `PATH`, even though it is on your interactive shell `PATH`. Run the shell snippet under **macOS / Linux: one-time PATH setup** above and restart Claude Code.
 - **`ENOENT: uv_spawn 'csharp-roslyn-lsp'` on Windows** — the plugin's `bin/` directory is not on the Claude Code child-process `PATH`. Run the PowerShell snippet under **Windows: one-time PATH setup** above and restart Claude Code.
 - **`VS Code C# extension not found`** — install the extension. The Unix launcher globs `~/.vscode/extensions/ms-dotnettools.csharp-*-<os>-<arch>`; the Windows launcher globs `%USERPROFILE%\.vscode\extensions\ms-dotnettools.csharp-*-win32-<arch>`. If you use a non-standard VS Code variant (e.g. a portable install), make sure that extensions directory exists.
 - **`no .NET host found`** — install either the VS Code C# extension (it brings a matching .NET runtime via `ms-dotnettools.vscode-dotnet-runtime`) or .NET 10+ system-wide. The Windows launcher additionally checks `%APPDATA%\Code\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\<ver>~<arch>~aspnetcore\dotnet.exe`.


### PR DESCRIPTION
## Summary
- Adds a **macOS / Linux: one-time PATH setup** section to `plugins/csharp-roslyn-lsp/README.md`, mirroring the existing Windows section. The Claude Code LSP child process does not inherit the plugin's `bin/` on macOS/Linux either — symlinking the launcher into `~/.local/bin` works around it.
- Adds a matching troubleshooting bullet for the `Executable not found in $PATH: "csharp-roslyn-lsp"` error.
- Bumps `csharp-roslyn-lsp` to `1.1.1` (also syncs `plugin.json`, which was stale at `1.0.0`) and the marketplace to `1.14.6`.

Fixes #22 — picks the issue's Option 1 (README docs); Options 2 (postinstall symlink) and 3 (upstream Claude Code fix) are out of scope for this repo.

## Test plan
- [ ] Fresh install of `csharp-roslyn-lsp@from2001-useful-skills` on macOS arm64 reproduces the original error.
- [ ] Running the documented snippet creates `~/.local/bin/csharp-roslyn-lsp` symlinked to the cached launcher.
- [ ] After restarting Claude Code, `LSP documentSymbol` on a Unity-generated `.cs` file returns symbols.
- [ ] Windows PATH section still renders/works as before (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)